### PR TITLE
Event handlers in states with concurrent substates get triggered multiple times

### DIFF
--- a/frameworks/foundation/system/statechart.js
+++ b/frameworks/foundation/system/statechart.js
@@ -918,7 +918,8 @@ Ki.StatechartManager = {
         len = 0,
         i = 0,
         state = null,
-        trace = this.get('allowTracing');
+        trace = this.get('allowTracing'),
+        attemptedStates = [];
     
     if (this._sendEventLocked || this._goStateLocked) {
       // Want to prevent any actions from being processed by the states until 
@@ -945,6 +946,8 @@ Ki.StatechartManager = {
       state = currentStates[i];
       if (!state.get('isCurrentState')) continue;
       while (!eventHandled && state) {
+        if (attemptedStates.indexOf(state) !== -1) break;
+        attemptedStates.push(state);
         eventHandled = state.tryToHandleEvent(event, arg1, arg2);
         if (!eventHandled) state = state.get('parentState');
         else statechartHandledEvent = YES;

--- a/frameworks/foundation/tests/event_handling/basic/with_concurrent_states.js
+++ b/frameworks/foundation/tests/event_handling/basic/with_concurrent_states.js
@@ -64,8 +64,14 @@ module("Ki.Statechart: With Concurrent States - Send Event Tests", {
           
         }),
         
-        y: Ki.State.design()
-        
+        y: Ki.State.design(),
+
+        numEventEInvocations: 0,
+
+        eventE: function() {
+          var num = this.get('numEventEInvocations');
+          this.set('numEventEInvocations', num + 1);
+        }
       })
       
     });
@@ -166,6 +172,18 @@ test("send event eventD", function() {
   equals(statechart.stateIsCurrentState('c'), false, 'current state not should be c');
   equals(statechart.stateIsCurrentState('e'), false, 'current state not should be e');
   equals(statechart.stateIsCurrentState('y'), true, 'current state should be y');
+});
+
+test("send event eventE", function() {
+  equals(statechart.stateIsCurrentState('c'), true, 'current state should be c');
+  equals(statechart.stateIsCurrentState('e'), true, 'current state should be e');
+
+  statechart.sendEvent('eventE');
+
+  equals(statechart.stateIsCurrentState('c'), true, 'current state should be c');
+  equals(statechart.stateIsCurrentState('e'), true, 'current state should be e');
+
+  equals(statechart.getPath('rootState.numEventEInvocations'), 1, 'eventE should be invoked only once')
 });
 
 test("send event eventZ", function() {


### PR DESCRIPTION
Consider the following statechart:

```
Test.statechart = Ki.Statechart.create({
  initialState: 'foo',
  foo: Ki.State.design({
    substatesAreConcurrent: YES,
    bar: Ki.State.design(),
    baz: Ki.State.design(),
    eventX: function() {
      console.log('eventX handled');
    }
  })
});
```

Sending the event `eventX` in the initial state will cause the eventX handler to be called twice.  This is not what I would expect and this patch ensures that handlers are only triggered once per state.
